### PR TITLE
’No knobs’ is displayed when number of fields is 0

### DIFF
--- a/src/components/Panel.js
+++ b/src/components/Panel.js
@@ -35,7 +35,7 @@ export default class Panel extends React.Component {
     this._setInitialFields = this.setInitialFields.bind(this);
     this._indicateReady = this.indicateReady.bind(this);
 
-    this.state = { fields: null };
+    this.state = { fields: {} };
     this.api = this.props.api;
   }
 
@@ -56,7 +56,6 @@ export default class Panel extends React.Component {
 
   componentDidMount() {
     this.stopOnStory = this.api.onStory(() => {
-      this.setState({ fields: null });
       this.api.setQueryParams({ knobs: null });
     });
 
@@ -112,7 +111,10 @@ export default class Panel extends React.Component {
   }
 
   render() {
-    if (!this.state.fields) {
+    const fields = this.state.fields;
+    const fieldsArray = Object.keys(fields).map(key => (fields[key]));
+
+    if (fieldsArray.length === 0) {
       return (
         <div style={styles.noKnobs}>NO KNOBS</div>
       );
@@ -120,7 +122,7 @@ export default class Panel extends React.Component {
 
     return (
       <div style={styles.panel}>
-        <PropForm fields={this.state.fields} onFieldChange={this._handleChange} />
+        <PropForm fields={fieldsArray} onFieldChange={this._handleChange} />
         <button style={styles.resetButton} onClick={this._reset}>RESET</button>
       </div>
     );

--- a/src/components/PropForm.js
+++ b/src/components/PropForm.js
@@ -31,15 +31,14 @@ export default class propForm extends React.Component {
 
   render() {
     const fields = this.props.fields;
-    const propArray = Object.keys(fields).map(key => (fields[key]));
 
-    propArray.sort(function (a, b) {
+    fields.sort(function (a, b) {
       return a.name > b.name;
     });
 
     return (
       <form style={stylesheet.propForm}>
-        {propArray.map(field => (
+        {fields.map(field => (
           <PropField
             key={field.name}
             name={field.name}
@@ -56,6 +55,6 @@ export default class propForm extends React.Component {
 propForm.displayName = 'propForm';
 
 propForm.propTypes = {
-  fields: React.PropTypes.object.isRequired,
+  fields: React.PropTypes.array.isRequired,
   onFieldChange: React.PropTypes.func.isRequired,
 };


### PR DESCRIPTION
Previously it was set to null when switching between stories. This is removed to avoid ’No knobs’ showing for a small time between stories.
