### PR TITLE
Check if url params are present before setting knob values from them

### DIFF
--- a/src/components/Panel.js
+++ b/src/components/Panel.js
@@ -60,8 +60,11 @@ export default class Panel extends React.Component {
       // For the first time, get values from the URL and set them.
       if (!this.loadedFromUrl) {
         const urlValue = api.getQueryParam(`knob-${name}`);
-        knob.value = Types[knob.type].deserialize(urlValue);
-        channel.emit('addon:knobs:knobChange', knob);
+
+        if (urlValue !== undefined) { // If the knob value present in url
+          knob.value = Types[knob.type].deserialize(urlValue);
+          channel.emit('addon:knobs:knobChange', knob);
+        }
       }
 
       queryParams[`knob-${name}`] = Types[knob.type].serialize(knob.value);


### PR DESCRIPTION
Otherwise when url-params are not given null values will be set overriding the given defaults.
