### PR TITLE
Fix issue where hot reloaded updates were not rendered

### DIFF
--- a/dist/components/WrapStory.js
+++ b/dist/components/WrapStory.js
@@ -60,6 +60,11 @@ var WrapStory = function (_React$Component) {
       this.setPaneKnobs();
     }
   }, {
+    key: 'componentWillReceiveProps',
+    value: function componentWillReceiveProps(props) {
+      this.setState({ storyContent: props.initialContent });
+    }
+  }, {
     key: 'componentWillUnmount',
     value: function componentWillUnmount() {
       this.props.channel.removeListener('addon:knobs:knobChange', this.knobChanged);

--- a/dist/index.js
+++ b/dist/index.js
@@ -49,7 +49,7 @@ function select(name, options, value) {
 }
 
 function date(name) {
-  var value = arguments.length <= 1 || arguments[1] === undefined ? new Date() : arguments[1];
+  var value = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : new Date();
 
   var proxyValue = value ? value.getTime() : null;
   return manager.knob(name, { type: 'date', value: proxyValue });

--- a/src/components/WrapStory.js
+++ b/src/components/WrapStory.js
@@ -22,6 +22,10 @@ export default class WrapStory extends React.Component {
     this.setPaneKnobs();
   }
 
+  componentWillReceiveProps(props) {
+    this.setState({ storyContent: props.initialContent });
+  }
+
   componentWillUnmount() {
     this.props.channel.removeListener('addon:knobs:knobChange', this.knobChanged);
     this.props.channel.removeListener('addon:knobs:reset', this.resetKnobs);


### PR DESCRIPTION
Need to re-render WrapStory when story is updated with hot reloading.